### PR TITLE
Adding new parameters for passthrough to Redis module

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Catalyst-Plugin-Session-Store-Redis
 
 {{$NEXT}}
+    - Adding ssl, name, username, password and alternative reconnect parameter
 
 0.900     2021-01-08 23:07:36+01:00
     - dist housekeeping, Dist::Zilla::PluginBundle::Author::DOMM

--- a/lib/Catalyst/Plugin/Session/Store/Redis.pm
+++ b/lib/Catalyst/Plugin/Session/Store/Redis.pm
@@ -93,9 +93,15 @@ sub _verify_redis_connection {
     } catch {
         $c->_session_redis_storage(
             Redis->new(
-                server    => $cfg->{redis_server}    || '127.0.0.1:6379',
-                debug     => $cfg->{redis_debug}     || 0,
-                reconnect => $cfg->{redis_reconnect} || 0
+                server                 => $cfg->{redis_server}                 || '127.0.0.1:6379',
+                debug                  => $cfg->{redis_debug}                  || 0,
+                reconnect              => $cfg->{redis_reconnect}              || 0,
+                conservative_reconnect => $cfg->{redis_conservative_reconnect} || 0,
+                ssl                    => $cfg->{redis_ssl}                    || 0,
+                ( ( $cfg->{redis_ssl_verify_mode} and $cfg->{redis_ssl} ) ? ( SSL_verify_mode => $cfg->{redis_ssl_verify_mode} ) : () ),
+                ( $cfg->{redis_name} ? ( name => $cfg->{redis_name} ) : () ),
+                ( $cfg->{redis_username} ? ( username => $cfg->{redis_username} ) : () ),
+                ( $cfg->{redis_password} ? ( password => $cfg->{redis_password} ) : () ),
             )
         );
         if ($c->_session_redis_storage && $cfg->{redis_db}) {
@@ -122,6 +128,11 @@ __END__
         redis_debug => 0, # or 1!
         redis_reconnect => 0, # or 1
         redis_db => 5, # or 0 by default
+        redis_ssl => 1, # or 0
+        redis_name => 'name',
+        redis_username => 'username', # or default user
+        redis_password => 'password',
+        redis_ssl_verify_mode => SSL_VERIFY_PEER, # IO::Socket::SSL
     };
 
     # ... in an action:
@@ -158,6 +169,40 @@ server was restarted.
 I leave the default of setting at C<0> for now because changing it
 might break existing apps.
 
+Do not use this setting with authentication.
+
+=head3 redis_conservative_reconnect
+
+Boolean flag. Default: 0, i.e. off.
+
+Use this setting for reconnect with authentication.
+
+=head3 redis_ssl
+
+Boolean flag. Default: 0, i.e. off.
+
+You can connect to Redis over SSL/TLS by setting this flag if the
+target Redis server or cluster has been setup to support SSL/TLS.
+This requires L<IO::Socket::SSL> to be installed on the client. It's off by default.
+
+=head3 redis_ssl_verify_mode
+
+This parameter will be applied when C<redis_ssl> flag is set. It sets
+the verification mode for the peer certificate. It's compatible with
+the parameter with the same name in L<IO::Socket::SSL>.
+
+=head3 redis_name
+
+Setting a different name for the connection.
+
+=head3 redis_username
+
+The username for the authentication
+
+=head3 redis_password
+
+The password, if your Redis server requires authentication.
+
 =head1 NOTES
 
 =over 4
@@ -191,6 +236,8 @@ Thomas Klausner C<< domm@cpan.org >>
 =item * Andreas Granig L<https://github.com/agranig>
 
 =item * Mohammad S Anwar L<https://github.com/manwar>
+
+=item * Torsten Raudssus L<https://github.com/Getty>
 
 =back
 


### PR DESCRIPTION
The module wasn't able to support username, password, ssl and other parameters that are helpful to make Redis work. Also added conservative_reconnect as the other reconnect doesn't work with authentication, I might will debug that.